### PR TITLE
Feat/addional config ch

### DIFF
--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -37,6 +37,18 @@ class CustomizeCommitsCz(BaseCommitizen):
         if custom_change_type_order:
             self.change_type_order = custom_change_type_order
 
+        commit_parser = self.custom_settings.get("commit_parser")
+        if commit_parser:
+            self.commit_parser = commit_parser
+
+        changelog_pattern = self.custom_settings.get("changelog_pattern")
+        if changelog_pattern:
+            self.changelog_pattern = changelog_pattern
+
+        change_type_map = self.custom_settings.get("change_type_map")
+        if change_type_map:
+            self.change_type_map = change_type_map
+
     def questions(self) -> List[Dict[str, Any]]:
         return self.custom_settings.get("questions")
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -28,6 +28,9 @@ info_path = "cz_customize_info.txt"
 info = """
 This is customized info
 """
+commit_parser = "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
+changelog_pattern = "^(feature|bug fix)?(!)?"
+change_type_map = {"feature" = "Feat", "bug fix" = "Fix"}
 
 [[tool.commitizen.customize.questions]]
 type = "list"
@@ -68,6 +71,9 @@ The equivalent example for a json config file:
             "change_type_order": ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"],
 	    "info_path": "cz_customize_info.txt",
             "info": "This is customized info",
+            "commit_parser": "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?",
+            "changelog_pattern": "^(feature|bug fix)?(!)?",
+            "change_type_map": {"feature": "Feat", "bug fix": "Fix"},
             "questions": [
                 {
                     "type": "list",
@@ -111,6 +117,11 @@ commitizen:
     schema: "<type>: <body>"
     schema_pattern: "(feature|bug fix):(\\s.*)"
     bump_pattern: "^(break|new|fix|hotfix)"
+    commit_parser: "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?",
+    changelog_pattern: "^(feature|bug fix)?(!)?",
+    change_type_map:
+      feature: Feat
+      bug fix: Fix
     bump_map:
       break: MAJOR
       new: MINOR
@@ -150,8 +161,12 @@ commitizen:
 | `bump_map`          | `dict` | `None`  | (OPTIONAL) Dictionary mapping the extracted information to a `SemVer` increment type (`MAJOR`, `MINOR`, `PATCH`)                                                                                                                 |
 | `bump_pattern`      | `str`  | `None`  | (OPTIONAL) Regex to extract information from commit (subject and body)                                                                                                                                                           |
 | `change_type_order` | `str`  | `None`  | (OPTIONAL) List of strings used to order the Changelog. All other types will be sorted alphabetically. Default is `["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]`                                                       |
+| `commit_parser`     | `str`  | `None`  | (OPTIONAL) Regex to extract information used in creating changelog. [See more][changelog-spec]                                                                                                                                   |
+| `changelog_pattern` | `str`  | `None`  | (OPTIONAL) Regex to understand which commits to include in the changelog                                                                                                                                                         |
+| `change_type_map`   | `dict` | `None`  | (OPTIONAL) Dictionary mapping the type of the commit to a changelog entry                                                                                                                                                        |
 
 [jinja2]: https://jinja.palletsprojects.com/en/2.10.x/
+[changelog-spec]: https://commitizen-tools.github.io/commitizen/changelog/
 #### Detailed `questions` content
 
 | Parameter | Type   | Default | Description                                                                                                                                                                                     |
@@ -170,7 +185,7 @@ commitizen:
 When the [`use_shortcuts`](https://commitizen-tools.github.io/commitizen/config/#settings) config option is enabled, commitizen can show and use keyboard shortcuts to select items from lists directly.
 For example, when using the `cz_conventional_commits` commitizen template, shortcut keys are shown when selecting the commit type. Unless otherwise defined, keyboard shortcuts will be numbered automatically.
 To specify keyboard shortcuts for your custom choices, provide the shortcut using the `key` parameter in dictionary form for each choice you would like to customize.
- 
+
 ## 2. Customize through customizing a class
 
 The basic steps are:

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -10,6 +10,9 @@ TOML_STR = r"""
     example = "feature: this feature enable customize through config file"
     schema = "<type>: <body>"
     schema_pattern = "(feature|bug fix):(\\s.*)"
+    commit_parser = "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
+    changelog_pattern = "^(feature|bug fix)?(!)?"
+    change_type_map = {"feature" = "Feat", "bug fix" = "Fix"}
 
     bump_pattern = "^(break|new|fix|hotfix)"
     bump_map = {"break" = "MAJOR", "new" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH"}
@@ -57,6 +60,9 @@ JSON_STR = r"""
                     "fix": "PATCH",
                     "hotfix": "PATCH"
                 },
+                "commit_parser": "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?",
+                "changelog_pattern": "^(feature|bug fix)?(!)?",
+                "change_type_map": {"feature": "Feat", "bug fix": "Fix"},
                 "change_type_order": ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"],
                 "info": "This is a customized cz.",
                 "questions": [
@@ -363,3 +369,18 @@ def test_info_with_info_path(tmpdir, config_info):
 def test_info_without_info(config_without_info):
     cz = CustomizeCommitsCz(config_without_info)
     assert cz.info() is None
+
+
+def test_commit_parser(config):
+    cz = CustomizeCommitsCz(config)
+    assert cz.commit_parser == "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
+
+
+def test_changelog_pattern(config):
+    cz = CustomizeCommitsCz(config)
+    assert cz.changelog_pattern == "^(feature|bug fix)?(!)?"
+
+
+def test_change_type_map(config):
+    cz = CustomizeCommitsCz(config)
+    assert cz.change_type_map == {"feature": "Feat", "bug fix": "Fix"}


### PR DESCRIPTION
## Description
Adding commit_parser, changelog_pattern, change_type_map as customizable fields in customize.py

I noticed that when customizing the tool, the changelog was not properly created, given the impossibility to specify a commit_parser. While adding the feature, I also added the possibility to specify a regex for changelog_pattern and the mapping contained in change_type_map.


## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [X] Update the documentation for the changes

## Expected behavior
When creating a changelog with a user-defined regex, the changelog should have the correct entries.

![image](https://user-images.githubusercontent.com/15369570/136054212-6753bab4-1a39-4004-ab52-f94f2c38c5f3.png)

## Steps to Test This Pull Request

1. define a custom setup
2. check that the changelog is created correctly using the defined regex

